### PR TITLE
[ci skip] adding user @awvwgk

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,2 @@
 * @SylvainCorlay @davidbrochart @minrk
+* @awvwgk

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -51,6 +51,7 @@ about:
 
 extra:
     recipe-maintainers:
+      - awvwgk
       - minrk
       - davidbrochart
       - SylvainCorlay


### PR DESCRIPTION

Hi! This is the friendly automated conda-forge-webservice.

I've added user @awvwgk as instructed in #23.

Merge this PR to add the user. Please do not rerender this PR or change it in any way. It has `[ci skip]` in the commit message to avoid pushing a new build and so the build configuration in the feedstock should not be changed.

Fixes #23