### PR TITLE
copy patches from debian to remove mc64

### DIFF
--- a/recipe/mc64ad_dist-stub.patch
+++ b/recipe/mc64ad_dist-stub.patch
@@ -1,0 +1,31 @@
+mc64ad_dist.c was removed (DFSG nonfree), create stubs
+--- /dev/null
++++ b/SRC/prec-independent/mc64ad_dist.c
+@@ -0,0 +1,27 @@
++/* The original mc64ad_dist.c is nonfree and has been removed.
++   We provide a stub interface here instead.
++*/
++
++#include <stdio.h>
++#include <stdlib.h>
++
++#include "superlu_ddefs.h"
++
++/* only mc64id_dist and mc64ad_dist are referenced by SuperLU-Dist code */
++
++/* Subroutine */ int_t mc64id_dist(int_t *icntl)
++{
++    fprintf(stderr, "SuperLU-Dist: MC64 functionality not available.\n(It uses code under a non-free HSL licence which does not permit redistribution).\nAborting mc64id_dist.\n");
++    abort();
++    return 0;
++}
++
++int_t mc64ad_dist(int_t *job, int_t *n, int_t *ne, int_t *
++	ip, int_t *irn, double *a, int_t *num, int_t *cperm,
++	int_t *liw, int_t *iw, int_t *ldw, double *dw, int_t *
++	icntl, int_t *info)
++{
++    fprintf(stderr, "SuperLU-Dist: MC64 functionality not available.\n(It uses code under a non-free HSL licence which does not permit redistribution).\nAborting mc64ad_dist.\n");
++    abort();
++    return 0;
++}

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -10,9 +10,14 @@ package:
 source:
   url: https://github.com/xiaoyeli/superlu_dist/archive/refs/tags/v${{ version }}.tar.gz
   sha256: c80a1c2edaaa451ee9a54e005e5f3f56dc55cabe2b0a8d7acf5a1447a648157a
+  patches:
+    # patches from debian to remove mc64,
+    # which has a non-free license that doesn't permit redistribution
+    - mc64ad_dist-stub.patch
+    - rowperm_default_NOROWPERM_not_MC64.patch
 
 build:
-  number: 0
+  number: 1
   skip: win
 
 requirements:

--- a/recipe/rowperm_default_NOROWPERM_not_MC64.patch
+++ b/recipe/rowperm_default_NOROWPERM_not_MC64.patch
@@ -1,0 +1,13 @@
+Index: superlu-dist/SRC/prec-independent/util.c
+===================================================================
+--- superlu-dist.orig/SRC/prec-independent/util.c	2025-12-21 13:56:00.686076922 +0100
++++ superlu-dist/SRC/prec-independent/util.c	2025-12-21 13:56:00.680188872 +0100
+@@ -215,7 +215,7 @@
+ #else
+     options->ColPerm = MMD_AT_PLUS_A;
+ #endif
+-    options->RowPerm = LargeDiag_MC64;
++    options->RowPerm = NOROWPERM;
+     options->ReplaceTinyPivot = NO;
+     options->IterRefine = SLU_DOUBLE;
+     options->Trans = NOTRANS;


### PR DESCRIPTION
license not compatible with redistribution

source: https://salsa.debian.org/science-team/superlu-dist/-/tree/master/debian/patches